### PR TITLE
add dogstatsd plugin

### DIFF
--- a/dogstatsd/README.md
+++ b/dogstatsd/README.md
@@ -1,6 +1,3 @@
-# consul
-
-## Name
 # dogstatsd
 
 ## Name

--- a/dogstatsd/README.md
+++ b/dogstatsd/README.md
@@ -1,0 +1,69 @@
+# consul
+
+## Name
+# dogstatsd
+
+## Name
+
+*dogstatsd* - publish coredns metrics to dogstatsd agents
+
+## Description
+
+CoreDNS has a builtin mechanism for exposing metrics to Prometheus over a HTTP
+endpoint, but infrastructures that use a metric collection system based on
+dogstatsd have to run a bridge to poll CoreDNS's metrics endpoint and push them
+to a dogstatsd agent.
+
+The *dogstatsd* plugin removes the need for a such bridge by allowing CoreDNS to
+directly push its metrics to a dogstatsd agent over UDP.
+
+## Syntax
+
+~~~ txt
+consul [ADDR:PORT]
+~~~
+
+* **ADDR** Address at which a dogstatsd agent is available. It may be prefixed
+with udp://, udp4://, udp6://, or unixgram:// to indicate the protocal to use
+to push metrics to a dogstatsd agent. If unxigram:// is specified the address
+must be a path to a unix domain socket on the file system.
+* **PORT** Port number at which the dogstatsd agent is accepting metrics. The
+port must not be set when the unixgram:// protocol is used to push metrics to
+a dogstatsd agent.
+
+If you want more control:
+
+~~~ txt
+dogstatsd [ADDR:PORT] {
+    buffer SIZE
+    flush INTERVAL
+}
+~~~
+
+* **ttl** configured how long responses from querying lists of services from
+  consul are cached for. **DURATION** defaults to 1m.
+* `prefetch` will prefetch popular items when they are about to be expunged
+  from the cache.
+  Popular means **AMOUNT** queries have been seen with no gaps of **DURATION**
+  or more between them. **DURATION** defaults to 1m. Prefetching will happen
+  when the TTL drops below **PERCENTAGE**, which defaults to `10%`, or latest 1
+  second before TTL expiration. Values should be in the range `[10%, 90%]`.
+  Note the percent sign is mandatory. **PERCENTAGE** is treated as an `int`.
+
+## Examples
+
+Enable the dogstatsd plugin with a client buffer size of 8 KB, and flushing
+metrics every 10 seconds.
+
+~~~ corefile
+. {
+    dogstatsd localhost:8125 {
+        buffer 8192
+        flush 10s
+    }
+}
+~~~
+
+### plugins.cfg
+
+This plugin is intended to appear right after the prometheus plugin declaration.

--- a/dogstatsd/README.md
+++ b/dogstatsd/README.md
@@ -20,7 +20,7 @@ directly push its metrics to a dogstatsd agent over UDP.
 ## Syntax
 
 ~~~ txt
-consul [ADDR:PORT]
+dogstatsd [ADDR:PORT]
 ~~~
 
 * **ADDR** Address at which a dogstatsd agent is available. It may be prefixed
@@ -40,15 +40,11 @@ dogstatsd [ADDR:PORT] {
 }
 ~~~
 
-* **ttl** configured how long responses from querying lists of services from
-  consul are cached for. **DURATION** defaults to 1m.
-* `prefetch` will prefetch popular items when they are about to be expunged
-  from the cache.
-  Popular means **AMOUNT** queries have been seen with no gaps of **DURATION**
-  or more between them. **DURATION** defaults to 1m. Prefetching will happen
-  when the TTL drops below **PERCENTAGE**, which defaults to `10%`, or latest 1
-  second before TTL expiration. Values should be in the range `[10%, 90%]`.
-  Note the percent sign is mandatory. **PERCENTAGE** is treated as an `int`.
+* **buffer** configures the size of the client buffer used to push metrics to a
+dogstatsd agent. This must not exceed the size of the receive buffer used by the
+agent. The minimum size is 512 B, the maximum is 64 KB.
+* **flush** configures the time interval between flushes of metrics to a
+dogstatsd agent. The minimum interval is 1 second, there is not maximum.
 
 ## Examples
 

--- a/dogstatsd/dogstatsd.go
+++ b/dogstatsd/dogstatsd.go
@@ -1,0 +1,238 @@
+package dogstatsd
+
+import (
+	"context"
+	"log"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/coredns/coredns/plugin"
+	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Dogstatsd is the implementation of the dogstasd coredns plugin.
+type Dogstatsd struct {
+	Next plugin.Handler
+
+	// Address of the dogstatsd agent to push metrics to.
+	Addr string
+
+	// Size of the socket buffer used to push metrics to the dogstatsd agent.
+	BufferSize int
+
+	// Time interval between flushes of metrics to the dogstasd agent.
+	FlushInterval time.Duration
+
+	// Reg is the prometheus registry used by the metrics plugin where all
+	// metrics are registered.
+	Reg *prometheus.Registry
+
+	once   sync.Once
+	wg     sync.WaitGroup
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+const (
+	defaultAddr          = "udp://localhost:8125"
+	defaultBufferSize    = 1024
+	defaultFlushInterval = 1 * time.Minute
+)
+
+// New returns a new instance of a dogstatsd plugin.
+func New() *Dogstatsd {
+	return &Dogstatsd{
+		Addr:          defaultAddr,
+		BufferSize:    defaultBufferSize,
+		FlushInterval: defaultFlushInterval,
+	}
+}
+
+// Name returns the name of the plugin.
+func (d *Dogstatsd) Name() string { return "dogstatsd" }
+
+// ServeDNS satisfies the plugin.Handler interface.
+func (d *Dogstatsd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
+	return plugin.NextOrFailure(d.Name(), d.Next, ctx, w, r)
+}
+
+// Start the dogstatsd plugin. The method returns immediatly after starting the
+// plugin's internal goroutine.
+func (d *Dogstatsd) Start() {
+	d.once.Do(d.init)
+	d.wg.Add(1)
+	go d.run(d.ctx)
+}
+
+// Stop interrupts the runing plugin.
+func (d *Dogstatsd) Stop() {
+	d.cancel()
+	d.wg.Wait()
+}
+
+func (d *Dogstatsd) init() {
+	d.ctx, d.cancel = context.WithCancel(context.Background())
+}
+
+func (d *Dogstatsd) run(ctx context.Context) {
+	defer d.wg.Done()
+	log.Printf("[INFO] dogstatsd %s { buffer %d; flush %s }", d.Addr, d.BufferSize, d.FlushInterval)
+
+	ticker := time.NewTicker(d.FlushInterval)
+	defer ticker.Stop()
+
+	state := make(state)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			d.pulse(state)
+		}
+	}
+}
+
+func (d *Dogstatsd) pulse(state state) {
+	metrics, err := d.collect(state)
+
+	if err != nil {
+		log.Printf("[ERROR] collecting metrics: %s", err)
+		return
+	}
+
+	log.Printf("[INFO] flushing %d metrics to %s", len(metrics), d.Addr)
+
+	if err := d.flush(metrics); err != nil {
+		log.Printf("[ERROR] flushing metrics to the dogstatsd agent at %s: %s", d.Addr, err)
+	}
+}
+
+func (d *Dogstatsd) collect(state state) ([]metric, error) {
+	metricFamilies, err := d.Reg.Gather()
+	if err != nil {
+		return nil, err
+	}
+
+	metrics := make([]metric, 0, 2*len(metricFamilies))
+
+	for _, f := range metricFamilies {
+		for _, m := range f.Metric {
+			for _, v := range makeMetrics(f, m) {
+				metrics = append(metrics, state.observe(v)...)
+			}
+		}
+	}
+
+	return metrics, nil
+}
+
+func (d *Dogstatsd) flush(metrics []metric) error {
+	conn, bufferSize, err := dial(d.Addr, d.BufferSize)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	out := make([]byte, 0, bufferSize)
+	buf := make([]byte, 0, bufferSize)
+
+	for _, m := range metrics {
+		buf = appendMetric(buf[:0], m)
+
+		if len(buf) > bufferSize {
+			log.Printf("[WARN] dogstatsd metric of size %d B exceeds the configured buffer size of %d B", len(buf), bufferSize)
+			continue
+		}
+
+		if (len(out) + len(buf)) > bufferSize {
+			if _, err := conn.Write(out); err != nil {
+				return err
+			}
+			out = out[:0]
+		}
+
+		out = append(out, buf...)
+	}
+
+	if len(out) != 0 {
+		_, err = conn.Write(out)
+	}
+	return err
+}
+
+// taken from https://github.com/segmentio/stats/datadog
+func dial(address string, bufferSizeHint int) (conn net.Conn, bufferSize int, err error) {
+	var network = "udp"
+	var f *os.File
+
+	if i := strings.Index(address, "://"); i >= 0 {
+		network, address = address[:i], address[i+3:]
+	}
+
+	if conn, err = net.Dial(network, address); err != nil {
+		return
+	}
+
+	uc, ok := conn.(*net.UDPConn)
+	if !ok {
+		bufferSize = bufferSizeHint
+		return
+	}
+
+	if f, err = uc.File(); err != nil {
+		conn.Close()
+		return
+	}
+	defer f.Close()
+	fd := int(f.Fd())
+
+	// The kernel refuses to send UDP datagrams that are larger than the size of
+	// the size of the socket send buffer. To maximize the number of metrics
+	// sent in one batch we attempt to adjust the kernel buffer size to accept
+	// larger datagrams, or fallback to the default socket buffer size if it
+	// failed.
+	if bufferSize, err = syscall.GetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF); err != nil {
+		conn.Close()
+		return
+	}
+
+	// The kernel applies a 2x factor on the socket buffer size, only half of it
+	// is available to write datagrams from user-space, the other half is used
+	// by the kernel directly.
+	bufferSize /= 2
+
+	for bufferSizeHint > bufferSize && bufferSizeHint > 0 {
+		if err := syscall.SetsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_SNDBUF, bufferSizeHint); err == nil {
+			bufferSize = bufferSizeHint
+			break
+		}
+		bufferSizeHint /= 2
+	}
+
+	// Even tho the buffer agrees to support a bigger size it shouldn't be
+	// possible to send datagrams larger than 65 KB on an IPv4 socket, so let's
+	// enforce the max size.
+	const maxBufferSize = 65507
+	if bufferSize > maxBufferSize {
+		bufferSize = maxBufferSize
+	}
+
+	// Use the size hint as an upper bound, event if the socket buffer is
+	// larger, this gives control in situations where the receive buffer size
+	// on the other side is known but cannot be controlled so the client does
+	// not produce datagrams that are too large for the receiver.
+	//
+	// Related issue: https://github.com/DataDog/dd-agent/issues/2638
+	if bufferSize > bufferSizeHint {
+		bufferSize = bufferSizeHint
+	}
+
+	// Creating the file put the socket in blocking mode, reverting.
+	syscall.SetNonblock(fd, true)
+	return
+}

--- a/dogstatsd/dogstatsd.go
+++ b/dogstatsd/dogstatsd.go
@@ -1,5 +1,23 @@
 package dogstatsd
 
+// A word about the dogstatsd plugin implementation
+// ------------------------------------------------
+//
+// Prometheus is used to collect metrics across coredns. In order to publish
+// those metrics to a dogstatsd agent, the plugin acts as an internal collector
+// that scraps the metrics at regular interval (just like prometheus would do),
+// and publish them to the datadog agent.
+//
+// The complex parts about bridging between prometheus and dogstatsd are the
+// subtle variations in how they implement similar concepts. For example, in
+// prometheus counters are always incrementing values, but in dogstatsd only
+// the increments are published. Same goes with the summaries and historigrams
+// of prometheus, which are merged into a single histogram concept in dogstatsd.
+//
+// In order to provide meaningful insights, the translation layer has to
+// remember the state of the previous iteration in order to compute values to
+// push to the dogstatsd agent.
+
 import (
 	"context"
 	"log"

--- a/dogstatsd/dogstatsd_test.go
+++ b/dogstatsd/dogstatsd_test.go
@@ -1,0 +1,200 @@
+package dogstatsd
+
+import (
+	"io/ioutil"
+	"log"
+	"net"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	counter1 = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "coredns",
+		Subsystem: "segment",
+		Name:      "counter1",
+		Help:      "Test counter 1.",
+	})
+
+	counter2 = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "coredns",
+		Subsystem: "segment",
+		Name:      "counter2",
+		Help:      "Test counter 2.",
+	})
+
+	gauge1 = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "coredns",
+		Subsystem: "segment",
+		Name:      "gauge1",
+		Help:      "Test gauge 1.",
+		ConstLabels: prometheus.Labels{
+			"A": "1",
+			"B": "2",
+			"C": "3",
+		},
+	})
+
+	histogram1 = prometheus.NewHistogram(prometheus.HistogramOpts{
+		Namespace: "coredns",
+		Subsystem: "segment",
+		Name:      "histogram1",
+		Help:      "Test histogram 1.",
+		Buckets:   []float64{10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+	})
+)
+
+func init() {
+	log.SetOutput(ioutil.Discard)
+}
+
+func TestDogstatsd(t *testing.T) {
+	state := make(state)
+
+	server := dogstatsdServer()
+	defer server.Close()
+
+	d := New()
+	d.Addr = server.addr()
+	d.BufferSize = 100 // for the purpose of the test, forbidden otherwise
+	d.Reg = prometheus.NewRegistry()
+	d.Reg.MustRegister(
+		counter1,
+		counter2,
+		gauge1,
+		histogram1,
+	)
+
+	// simple case
+	counter1.Add(42)
+	counter2.Add(1)
+	gauge1.Set(10)
+	histogram1.Observe(0)
+	histogram1.Observe(12)
+	histogram1.Observe(12)
+	d.pulse(state)
+	assertRead(t, server,
+		"coredns.segment.counter1:42|c",
+		"coredns.segment.counter2:1|c",
+		"coredns.segment.gauge1:10|g|#a:1,b:2,c:3",
+		"coredns.segment.histogram1:5|h",
+		"coredns.segment.histogram1:12.5|h",
+		"coredns.segment.histogram1:17.5|h",
+	)
+
+	// repeated changes between each pulse, first one is a no-op (so only 19
+	// changes are pushed).
+	for i := 0; i != 20; i++ {
+		counter2.Add(float64(i))
+		d.pulse(state)
+	}
+	assertRead(t, server,
+		"coredns.segment.counter2:1|c",
+		"coredns.segment.counter2:2|c",
+		"coredns.segment.counter2:3|c",
+		"coredns.segment.counter2:4|c",
+		"coredns.segment.counter2:5|c",
+		"coredns.segment.counter2:6|c",
+		"coredns.segment.counter2:7|c",
+		"coredns.segment.counter2:8|c",
+		"coredns.segment.counter2:9|c",
+		"coredns.segment.counter2:10|c",
+		"coredns.segment.counter2:11|c",
+		"coredns.segment.counter2:12|c",
+		"coredns.segment.counter2:13|c",
+		"coredns.segment.counter2:14|c",
+		"coredns.segment.counter2:15|c",
+		"coredns.segment.counter2:16|c",
+		"coredns.segment.counter2:17|c",
+		"coredns.segment.counter2:18|c",
+		"coredns.segment.counter2:19|c",
+	)
+
+	for i := 0; i != 10; i++ {
+		histogram1.Observe(float64(i))
+	}
+	d.pulse(state)
+	assertRead(t, server,
+		"coredns.segment.histogram1:0.5|h",
+		"coredns.segment.histogram1:1.5|h",
+		"coredns.segment.histogram1:2.5|h",
+		"coredns.segment.histogram1:3.5|h",
+		"coredns.segment.histogram1:4.5|h",
+		"coredns.segment.histogram1:5.5|h",
+		"coredns.segment.histogram1:6.5|h",
+		"coredns.segment.histogram1:7.5|h",
+		"coredns.segment.histogram1:8.5|h",
+		"coredns.segment.histogram1:9.5|h",
+	)
+}
+
+func dogstatsdServer() server {
+	c, err := net.ListenPacket("udp", "127.0.0.1:")
+	if err != nil {
+		panic(err)
+	}
+
+	p := make(chan string, 1000)
+
+	go func(p chan<- string) {
+		defer close(p)
+		b := make([]byte, 65536)
+		c.SetReadDeadline(time.Now().Add(5 * time.Second)) // test lasts at most 5s
+		for {
+			n, _, err := c.ReadFrom(b)
+			if err != nil {
+				return
+			}
+			for _, line := range strings.Split(string(b[:n]), "\n") {
+				if line != "" {
+					p <- line
+				}
+			}
+		}
+	}(p)
+
+	return server{PacketConn: c, packets: p}
+}
+
+type server struct {
+	net.PacketConn
+	packets <-chan string
+}
+
+func (s server) addr() string {
+	a := s.LocalAddr()
+	return a.Network() + "://" + a.String()
+}
+
+func assertRead(t *testing.T, s server, packets ...string) {
+	found := make([]string, 0, len(packets))
+	expected := make([]string, len(packets))
+	copy(expected, packets)
+
+	for range expected {
+		p, ok := <-s.packets
+		if ok {
+			found = append(found, p)
+		} else {
+			t.Error("unexpected EOF")
+			t.Logf("expected:\n%q", expected)
+			t.Logf("found:\n%q", found)
+			return
+		}
+	}
+
+	// UDP doesn't garantee order, all we care about is getting all the packets.
+	sort.Strings(found)
+	sort.Strings(expected)
+
+	if !reflect.DeepEqual(found, expected) {
+		t.Errorf("packets mismatch")
+		t.Logf("expected:\n%q", expected)
+		t.Logf("found:\n%q", found)
+	}
+}

--- a/dogstatsd/dogstatsd_test.go
+++ b/dogstatsd/dogstatsd_test.go
@@ -87,8 +87,8 @@ func testDogstatsdSimple(t *testing.T, plugin *Dogstatsd, server server, state s
 	counter2.Add(1)
 	gauge1.Set(10)
 	histogram1.Observe(0)
-	histogram1.Observe(12)
-	histogram1.Observe(12)
+	histogram1.Observe(42)
+	histogram1.Observe(42)
 
 	plugin.pulse(state)
 	assertRead(t, server,
@@ -96,7 +96,7 @@ func testDogstatsdSimple(t *testing.T, plugin *Dogstatsd, server server, state s
 		"coredns.segment.counter2:1|c",
 		"coredns.segment.gauge1:10|g|#a:1,b:2,c:3",
 		"coredns.segment.histogram1:0|h",
-		"coredns.segment.histogram1:10|h|@0.5",
+		"coredns.segment.histogram1:40|h|@0.5",
 	)
 }
 

--- a/dogstatsd/metric.go
+++ b/dogstatsd/metric.go
@@ -61,8 +61,6 @@ func makeMetrics(f *dto.MetricFamily, m *dto.Metric, rand func(min, max float64)
 		acc := uint64(0)
 		min := 0.0
 
-		//fmt.Printf("%+v\n", buckets)
-
 		for index, bucket := range buckets {
 			cct := *bucket.CumulativeCount
 			max := *bucket.UpperBound

--- a/dogstatsd/metric.go
+++ b/dogstatsd/metric.go
@@ -144,10 +144,10 @@ func appendTagName(b []byte, s string) []byte {
 		case isColumn(c):
 			// Not sure prometheus allows it but just in case.
 			b = append(b, '_')
+		case isAlphaUpper(c):
+			c = toLower(c)
+			fallthrough
 		case isValidTagRune(c):
-			if isAlphaUpper(c) {
-				c = toLower(c)
-			}
 			b = append(b, byte(c))
 		default:
 			b = append(b, '_')
@@ -159,10 +159,10 @@ func appendTagName(b []byte, s string) []byte {
 func appendTagValue(b []byte, s string) []byte {
 	for _, c := range s {
 		switch {
+		case isAlphaUpper(c):
+			c = toLower(c)
+			fallthrough
 		case isValidNameRune(c):
-			if isAlphaUpper(c) {
-				c = toLower(c)
-			}
 			b = append(b, byte(c))
 		default:
 			b = append(b, '_')

--- a/dogstatsd/metric.go
+++ b/dogstatsd/metric.go
@@ -176,7 +176,7 @@ func isValidNameRune(c rune) bool {
 }
 
 func isValidTagRune(c rune) bool {
-	return isAlphaNum(c) || isUnderscore(c) || isPeriod(c) || isMinus(c) || isSlash(c)
+	return isAlphaNum(c) || isUnderscore(c) || isPeriod(c) || isMinus(c) || isSlash(c) || isColumn(c)
 }
 
 func isAlphaNum(c rune) bool   { return isAlpha(c) || isNum(c) }

--- a/dogstatsd/metric.go
+++ b/dogstatsd/metric.go
@@ -1,23 +1,5 @@
 package dogstatsd
 
-// A word about the dogstatsd plugin implementation
-// ------------------------------------------------
-//
-// Prometheus is used to collect metrics across coredns. In order to publish
-// those metrics to a dogstatsd agent, the plugin acts as an internal collector
-// that scraps the metrics at regular interval (just like prometheus would do),
-// and publish them to the datadog agent.
-//
-// The complex parts about bridging between prometheus and dogstatsd are the
-// subtle variations in how they implement similar concepts. For example, in
-// prometheus counters are always incrementing values, but in dogstatsd only
-// the increments are published. Same goes with the summaries and historigrams
-// of prometheus, which are merged into a single histogram concept in dogstatsd.
-//
-// In order to provide meaningful insights, the translation layer has to
-// remember the state of the previous iteration in order to compute values to
-// push to the dogstatsd agent.
-
 import (
 	"strconv"
 

--- a/dogstatsd/metric.go
+++ b/dogstatsd/metric.go
@@ -1,0 +1,300 @@
+package dogstatsd
+
+// A word about the dogstatsd plugin implementation
+// ------------------------------------------------
+//
+// Prometheus is used to collect metrics across coredns. In order to publish
+// those metrics to a dogstatsd agent, the plugin acts as an internal collector
+// that scraps the metrics at regular interval (just like prometheus would do),
+// and publish them to the datadog agent.
+//
+// The complex parts about bridging between prometheus and dogstatsd are the
+// subtle variations in how they implement similar concepts. For example, in
+// prometheus counters are always incrementing values, but in dogstatsd only
+// the increments are published. Same goes with the summaries and historigrams
+// of prometheus, which are merged into a single histogram concept in dogstatsd.
+//
+// In order to provide meaningful insights, the translation layer has to
+// remember the state of the previous iteration in order to compute values to
+// push to the dogstatsd agent.
+
+import (
+	"strconv"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+type key struct {
+	kind   kind
+	name   string
+	tags   tags
+	bucket int
+}
+
+type kind int
+
+const (
+	counter   kind = 'c'
+	gauge     kind = 'g'
+	histogram kind = 'h'
+)
+
+type metric struct {
+	kind  kind
+	name  string
+	value float64
+	rate  float64
+	tags  tags
+
+	// bucket is the index of the histogram bucket that the metric was generated
+	// from. The count, min, and max values are used to represent the number of
+	// values observed by the histogram bucket and the range in which they were
+	// observed.
+	bucket int
+	count  uint64
+	min    float64
+	max    float64
+}
+
+func makeMetrics(f *dto.MetricFamily, m *dto.Metric) []metric {
+	tags := makeTags(m)
+
+	switch *f.Type {
+	case dto.MetricType_COUNTER:
+		return []metric{{
+			kind:  counter,
+			name:  *f.Name,
+			value: *m.Counter.Value,
+			tags:  tags,
+		}}
+
+	case dto.MetricType_GAUGE:
+		return []metric{{
+			kind:  gauge,
+			name:  *f.Name,
+			value: *m.Gauge.Value,
+			tags:  tags,
+		}}
+
+	case dto.MetricType_HISTOGRAM:
+		buckets := m.Histogram.Bucket
+		metrics := make([]metric, 0, len(buckets))
+		name := *f.Name
+		count := uint64(0)
+		min := 0.0
+
+		for index, bucket := range buckets {
+			cum := *bucket.CumulativeCount
+			max := *bucket.UpperBound
+
+			metrics = append(metrics, metric{
+				kind:   histogram,
+				name:   name,
+				tags:   tags,
+				bucket: index,
+				count:  cum - count,
+				min:    min,
+				max:    max,
+			})
+
+			count, min = cum, max
+		}
+
+		return metrics
+
+	default:
+		// case dto.MetricType_SUMMARY:
+		// case dto.MetricType_UNTYPED:
+		//
+		// For now summary and untyped metrics are not used in coredns, so we
+		// will skip generating them.
+		return nil
+	}
+}
+
+func appendMetric(b []byte, m metric) []byte {
+	b = appendName(b, m.name)
+	b = append(b, ':')
+	b = strconv.AppendFloat(b, m.value, 'g', -1, 64)
+	b = append(b, '|')
+	b = append(b, byte(m.kind))
+
+	if m.rate != 0 && m.rate != 1 {
+		b = append(b, '|', '@')
+		b = strconv.AppendFloat(b, m.rate, 'g', -1, 64)
+	}
+
+	if len(m.tags) != 0 {
+		b = append(b, '|', '#')
+		b = append(b, m.tags...)
+	}
+
+	return append(b, '\n')
+}
+
+func appendName(b []byte, s string) []byte {
+	// Dogstatsd metric names must start with a letter. Here we are not checking
+	// for this condition because in the context of coredns all metric names are
+	// prefixed with "coredns_" and therefore state with a letter.
+	for _, c := range s {
+		switch {
+		case isUnderscore(c):
+			// Dogstatsd systems use periods as namespace delimiers, whereas
+			// prometheus uses underscores. This may have the side effect of
+			// replacing underscores with periods in the metric name part of
+			// the prometheus metric, but it doesn't seem out of place in the
+			// context of a dogstatsd metric. We could have tried to identify
+			// the namespace and subsystem and only put periods for delimiters
+			// between those, but this is error prone and hard to reason about
+			// when it doesn't work as expected (think about a subsystem with
+			// underscores). To keep things simple, we just replace all initial
+			// underscores with periods.
+			b = append(b, '.')
+		case isValidNameRune(c):
+			b = append(b, byte(c))
+		default:
+			b = append(b, '_')
+		}
+	}
+	return b
+}
+
+func appendTagName(b []byte, s string) []byte {
+	for _, c := range s {
+		switch {
+		case isColumn(c):
+			// Not sure prometheus allows it but just in case.
+			b = append(b, '_')
+		case isValidTagRune(c):
+			if isAlphaUpper(c) {
+				c = toLower(c)
+			}
+			b = append(b, byte(c))
+		default:
+			b = append(b, '_')
+		}
+	}
+	return b
+}
+
+func appendTagValue(b []byte, s string) []byte {
+	for _, c := range s {
+		switch {
+		case isValidNameRune(c):
+			if isAlphaUpper(c) {
+				c = toLower(c)
+			}
+			b = append(b, byte(c))
+		default:
+			b = append(b, '_')
+		}
+	}
+	return b
+}
+
+func isValidNameRune(c rune) bool {
+	return isAlphaNum(c) || isUnderscore(c) || isPeriod(c)
+}
+
+func isValidTagRune(c rune) bool {
+	return isAlphaNum(c) || isUnderscore(c) || isPeriod(c) || isMinus(c) || isSlash(c)
+}
+
+func isAlphaNum(c rune) bool   { return isAlpha(c) || isNum(c) }
+func isAlpha(c rune) bool      { return isAlphaUpper(c) || isAlphaLower(c) }
+func isAlphaUpper(c rune) bool { return c >= 'A' && c <= 'Z' }
+func isAlphaLower(c rune) bool { return c >= 'a' && c <= 'z' }
+func isNum(c rune) bool        { return c >= '0' && c <= '9' }
+func isUnderscore(c rune) bool { return c == '_' }
+func isPeriod(c rune) bool     { return c == '.' }
+func isMinus(c rune) bool      { return c == '-' }
+func isSlash(c rune) bool      { return c == '/' }
+func isColumn(c rune) bool     { return c == ':' }
+func toLower(c rune) rune      { return c + ('a' - 'A') }
+
+type tags string
+
+func makeTags(m *dto.Metric) tags {
+	if len(m.Label) == 0 {
+		return ""
+	}
+
+	b := make([]byte, 0, 20*len(m.Label))
+
+	for i, p := range m.Label {
+		if i != 0 {
+			b = append(b, ',')
+		}
+		b = appendTagName(b, *p.Name)
+		b = append(b, ':')
+		b = appendTagValue(b, *p.Value)
+	}
+
+	return tags(b)
+}
+
+type state map[key]metric
+
+func (s state) observe(m metric) (metrics []metric) {
+	k := key{
+		kind:   m.kind,
+		name:   m.name,
+		tags:   m.tags,
+		bucket: m.bucket,
+	}
+
+	v, exist := s[k]
+
+	switch m.kind {
+	case counter:
+		// For counters we report the difference from the last value seen for
+		// the metric.
+		if !exist {
+			v = m
+			metrics = append(metrics, m)
+		} else {
+			delta := m.value - v.value
+			if delta < 0 { // counter reset
+				delta = m.value
+			}
+			if delta != 0 {
+				v.value = m.value
+				m.value = delta
+				metrics = append(metrics, m)
+			}
+		}
+
+	case gauge:
+		// For gauges we simply set the value, the prometheus and dogstatsd
+		// metric models use the same gauge concept.
+		if !exist {
+			v = m
+			metrics = append(metrics, m)
+		} else if v.value != m.value {
+			v.value = m.value
+			metrics = append(metrics, m)
+		}
+
+	case histogram:
+		// For histograms we generate a list of metrics that represent discrete
+		// observations spread out across the histogram bucket range.
+		// The difference in cumulative count is used to determine how many
+		// metrics we generate.
+		count := m.count - v.count
+		if count < 0 { // histogram reset
+			count = m.count
+		}
+		for i := uint64(0); i < count; i++ {
+			h := m
+			a := h.max - h.min
+			b := float64(i) + 0.5
+			c := float64(count)
+			h.value = h.min + ((a * b) / c)
+			metrics = append(metrics, h)
+		}
+		v = m
+	}
+
+	s[k] = v
+	return
+}

--- a/dogstatsd/metric_test.go
+++ b/dogstatsd/metric_test.go
@@ -1,0 +1,126 @@
+package dogstatsd
+
+import (
+	"testing"
+)
+
+var testMetrics = []struct {
+	s string
+	m metric
+}{
+	{
+		s: "test.metric.small:0|c\n",
+		m: metric{
+			kind:  counter,
+			name:  "test.metric.small",
+			value: 0,
+			rate:  1,
+		},
+	},
+
+	{
+		s: "test.metric.common:1|c|#hello:world,answer:42\n",
+		m: metric{
+			kind:  counter,
+			name:  "test.metric.common",
+			value: 1,
+			rate:  1,
+			tags:  "hello:world,answer:42",
+		},
+	},
+
+	{
+		s: "test.metric.large:1.234|c|@0.1|#hello:world,hello:world,hello:world,hello:world,hello:world,hello:world,hello:world,hello:world,hello:world,hello:world\n",
+		m: metric{
+			kind:  counter,
+			name:  "test.metric.large",
+			value: 1.234,
+			rate:  0.1,
+			tags:  "hello:world,hello:world,hello:world,hello:world,hello:world,hello:world,hello:world,hello:world,hello:world,hello:world",
+		},
+	},
+
+	{
+		s: "page.views:1|c\n",
+		m: metric{
+			kind:  counter,
+			name:  "page.views",
+			value: 1,
+			rate:  1,
+		},
+	},
+
+	{
+		s: "fuel.level:0.5|g\n",
+		m: metric{
+			kind:  gauge,
+			name:  "fuel.level",
+			value: 0.5,
+			rate:  1,
+		},
+	},
+
+	{
+		s: "song.length:240|h|@0.5\n",
+		m: metric{
+			kind:  histogram,
+			name:  "song.length",
+			value: 240,
+			rate:  0.5,
+		},
+	},
+
+	{
+		s: "users.uniques:1234|h\n",
+		m: metric{
+			kind:  histogram,
+			name:  "users.uniques",
+			value: 1234,
+			rate:  1,
+		},
+	},
+
+	{
+		s: "users.online:1|c|#country:china\n",
+		m: metric{
+			kind:  counter,
+			name:  "users.online",
+			value: 1,
+			rate:  1,
+			tags:  "country:china",
+		},
+	},
+
+	{
+		s: "users.online:1|c|@0.5|#country:china\n",
+		m: metric{
+			kind:  counter,
+			name:  "users.online",
+			value: 1,
+			rate:  0.5,
+			tags:  "country:china",
+		},
+	},
+}
+
+func TestAppendMetric(t *testing.T) {
+	for _, test := range testMetrics {
+		t.Run(test.m.name, func(b *testing.T) {
+			if s := string(appendMetric(nil, test.m)); s != test.s {
+				t.Errorf("\n<<< %#v\n>>> %#v", test.s, s)
+			}
+		})
+	}
+}
+
+func BenchmarkAppendMetric(b *testing.B) {
+	buffer := make([]byte, 4096)
+
+	for _, test := range testMetrics {
+		b.Run(test.m.name, func(b *testing.B) {
+			for i := 0; i != b.N; i++ {
+				appendMetric(buffer[:0], test.m)
+			}
+		})
+	}
+}

--- a/dogstatsd/setup.go
+++ b/dogstatsd/setup.go
@@ -1,0 +1,146 @@
+package dogstatsd
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/coredns/coredns/core/dnsserver"
+	"github.com/coredns/coredns/plugin"
+	"github.com/coredns/coredns/plugin/metrics"
+	"github.com/mholt/caddy"
+)
+
+func init() {
+	caddy.RegisterPlugin("dogstatsd", caddy.Plugin{
+		ServerType: "dns",
+		Action:     setup,
+	})
+}
+
+func setup(c *caddy.Controller) error {
+	d, err := dogstatsdParse(c)
+	if err != nil {
+		return plugin.Error("dogstatsd", err)
+	}
+
+	conf := dnsserver.GetConfig(c)
+	m, _ := conf.Handler("prometheus").(*metrics.Metrics)
+
+	if m == nil {
+		// The dogstatsd plugin needs the prometheus plugin to be loaded in
+		// order to function, if it wasn't yet we force the load here.
+		m = metrics.New("")
+		conf.AddPlugin(func(next plugin.Handler) plugin.Handler {
+			m.Next = next
+			return m
+		})
+	}
+
+	d.Reg = m.Reg
+	conf.AddPlugin(func(next plugin.Handler) plugin.Handler {
+		d.Next = next
+		return d
+	})
+
+	c.OnStartup(func() error {
+		d.Start()
+		return nil
+	})
+
+	c.OnShutdown(func() error {
+		d.Stop()
+		return nil
+	})
+	return nil
+}
+
+func dogstatsdParse(c *caddy.Controller) (*Dogstatsd, error) {
+	if !c.Next() { // 'dogstatsd'
+		return nil, c.Err("expected 'dogstatsd' token at the beginning of the dogstatsd plugin configuration block")
+	}
+
+	d := New()
+
+	switch args := c.RemainingArgs(); len(args) {
+	case 0:
+	case 1:
+		d.Addr = args[0]
+		if i := strings.Index(d.Addr, "://"); i < 0 {
+			d.Addr = "udp://" + d.Addr
+		} else {
+			switch d.Addr[:i] {
+			case "udp", "udp4", "udp6", "unixgram":
+			default:
+				return nil, c.Errf("unsupported protocol: %s", d.Addr[:i])
+			}
+		}
+	default:
+		return nil, c.ArgErr()
+	}
+
+	for c.NextBlock() {
+		switch c.Val() {
+		case "buffer":
+			bufferSize, err := dogstatsdParseBuffer(c)
+			if err != nil {
+				return nil, err
+			}
+			d.BufferSize = bufferSize
+
+		case "flush":
+			flushInterval, err := dogstatsdParseFlush(c)
+			if err != nil {
+				return nil, err
+			}
+			d.FlushInterval = flushInterval
+
+		default:
+			return nil, c.ArgErr()
+		}
+	}
+
+	return d, nil
+}
+
+func dogstatsdParseBuffer(c *caddy.Controller) (bufferSize int, err error) {
+	args := c.RemainingArgs()
+
+	if len(args) != 1 {
+		err = c.ArgErr()
+		return
+	}
+
+	if bufferSize, err = strconv.Atoi(args[0]); err != nil {
+		return
+	}
+
+	if bufferSize <= 512 {
+		err = c.Errf("the buffer size must be at least 512 B, got %d B", bufferSize)
+	}
+
+	if bufferSize > 65536 {
+		err = c.Errf("the buffer size must be at most 65536 B, got %d B", bufferSize)
+	}
+
+	return
+}
+
+func dogstatsdParseFlush(c *caddy.Controller) (flushInterval time.Duration, err error) {
+	args := c.RemainingArgs()
+
+	if len(args) != 1 {
+		err = c.ArgErr()
+		return
+	}
+
+	if flushInterval, err = time.ParseDuration(args[0]); err != nil {
+		return
+	}
+
+	if flushInterval < (1 * time.Second) {
+		err = c.Errf("the flush interval must be at least 1s, got %s", flushInterval)
+	}
+
+	return
+}


### PR DESCRIPTION
This PR adds a `dogstatsd` plugin which produces coredns metrics to a dogstatsd agent.

I have yet to fully integrate and test it with coredns so I may have to tweak some details of the setup, but the core logic is implemented and tested.

I left a comment with guidelines to understand the design in dogstatsd.go, this is a good place to start the review.

Please take a look and let me know if anything should be changed!