### PR TITLE
report top 10 names

### DIFF
--- a/dogstatsd/counters.go
+++ b/dogstatsd/counters.go
@@ -1,0 +1,63 @@
+package dogstatsd
+
+import (
+	"sort"
+	"sync"
+)
+
+// nameCounters is a data type that keep tracks of counts by names and can be
+// used to retrieve the top N most popular names.
+type nameCounters struct {
+	mutex    sync.Mutex
+	counters map[string]int64
+}
+
+func makeNameCounters() nameCounters {
+	return nameCounters{counters: make(map[string]int64, 1000)}
+}
+
+func (nc *nameCounters) incr(name string) {
+	nc.mutex.Lock()
+	nc.counters[name]++
+	nc.mutex.Unlock()
+}
+
+func (nc *nameCounters) top(n int) []nameCounter {
+	counters := nc.swap(make(map[string]int64, 1000))
+	names := make([]nameCounter, 0, len(counters))
+
+	for name, count := range counters {
+		names = append(names, nameCounter{
+			name:  name,
+			count: count,
+		})
+	}
+
+	sort.Sort(sort.Reverse(
+		nameCountersByCount(names),
+	))
+
+	if n < len(names) {
+		names = names[:n]
+	}
+
+	return names
+}
+
+func (nc *nameCounters) swap(counters map[string]int64) map[string]int64 {
+	nc.mutex.Lock()
+	counters, nc.counters = nc.counters, counters
+	nc.mutex.Unlock()
+	return counters
+}
+
+type nameCounter struct {
+	name  string
+	count int64
+}
+
+type nameCountersByCount []nameCounter
+
+func (names nameCountersByCount) Len() int           { return len(names) }
+func (names nameCountersByCount) Less(i, j int) bool { return names[i].count < names[j].count }
+func (names nameCountersByCount) Swap(i, j int)      { names[i], names[j] = names[j], names[i] }

--- a/dogstatsd/counters.go
+++ b/dogstatsd/counters.go
@@ -5,59 +5,64 @@ import (
 	"sync"
 )
 
-// nameCounters is a data type that keep tracks of counts by names and can be
-// used to retrieve the top N most popular names.
-type nameCounters struct {
-	mutex    sync.Mutex
-	counters map[string]int64
+// counterStore is a data type that keep tracks of counters indexed by keys and is
+// used to retrieve the top N most popular keys.
+type counterStore struct {
+	mutex sync.Mutex
+	index map[string]int64
 }
 
-func makeNameCounters() nameCounters {
-	return nameCounters{counters: make(map[string]int64, 1000)}
+func makeCounterStore() counterStore {
+	return counterStore{index: make(map[string]int64, 1000)}
 }
 
-func (nc *nameCounters) incr(name string) {
-	nc.mutex.Lock()
-	nc.counters[name]++
-	nc.mutex.Unlock()
+func (c *counterStore) incr(name string) {
+	c.mutex.Lock()
+	c.index[name]++
+	c.mutex.Unlock()
 }
 
-func (nc *nameCounters) top(n int) []nameCounter {
-	counters := nc.swap(make(map[string]int64, 1000))
-	names := make([]nameCounter, 0, len(counters))
+func (c *counterStore) top(n int) []counterEntry {
+	index := c.swap(make(map[string]int64, 1000))
+	count := make([]counterEntry, 0, len(index))
 
-	for name, count := range counters {
-		names = append(names, nameCounter{
-			name:  name,
-			count: count,
-		})
+	for key, value := range index {
+		count = append(count, counterEntry{key: key, value: value})
 	}
 
 	sort.Sort(sort.Reverse(
-		nameCountersByCount(names),
+		counterEntriesByValue(count),
 	))
 
-	if n < len(names) {
-		names = names[:n]
+	if n < len(count) {
+		count = count[:n]
 	}
-
-	return names
+	return count
 }
 
-func (nc *nameCounters) swap(counters map[string]int64) map[string]int64 {
-	nc.mutex.Lock()
-	counters, nc.counters = nc.counters, counters
-	nc.mutex.Unlock()
-	return counters
+func (c *counterStore) swap(m map[string]int64) map[string]int64 {
+	c.mutex.Lock()
+	m, c.index = c.index, m
+	c.mutex.Unlock()
+	return m
 }
 
-type nameCounter struct {
-	name  string
-	count int64
+type counterEntry struct {
+	key   string
+	value int64
 }
 
-type nameCountersByCount []nameCounter
+func (c counterEntry) metric(name string, tag string) metric {
+	return metric{
+		kind:  counter,
+		name:  name,
+		value: float64(c.value),
+		tags:  tags(tag + ":" + c.key),
+	}
+}
 
-func (names nameCountersByCount) Len() int           { return len(names) }
-func (names nameCountersByCount) Less(i, j int) bool { return names[i].count < names[j].count }
-func (names nameCountersByCount) Swap(i, j int)      { names[i], names[j] = names[j], names[i] }
+type counterEntriesByValue []counterEntry
+
+func (c counterEntriesByValue) Len() int           { return len(c) }
+func (c counterEntriesByValue) Less(i, j int) bool { return c[i].value < c[j].value }
+func (c counterEntriesByValue) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }

--- a/dogstatsd/counters_test.go
+++ b/dogstatsd/counters_test.go
@@ -5,31 +5,31 @@ import (
 	"testing"
 )
 
-func TestNameCounters(t *testing.T) {
-	nc := makeNameCounters()
+func TestCounterStore(t *testing.T) {
+	c := makeCounterStore()
 
 	for i := 0; i != 10; i++ {
-		nc.incr("www.segment.com.")
+		c.incr("www.segment.com.")
 	}
 
 	for i := 0; i != 4; i++ {
-		nc.incr("www.github.com.")
+		c.incr("www.github.com.")
 	}
 
 	for i := 0; i != 3; i++ {
-		nc.incr("www.google.com.")
+		c.incr("www.google.com.")
 	}
 
-	nc.incr("google.com.")
-	nc.incr("facebook.com.")
-	nc.incr("datadoghq.com.")
+	c.incr("google.com.")
+	c.incr("facebook.com.")
+	c.incr("datadoghq.com.")
 
-	top3 := nc.top(3)
+	top3 := c.top(3)
 
-	if !reflect.DeepEqual(top3, []nameCounter{
-		{name: "www.segment.com.", count: 10},
-		{name: "www.github.com.", count: 4},
-		{name: "www.google.com.", count: 3},
+	if !reflect.DeepEqual(top3, []counterEntry{
+		{key: "www.segment.com.", value: 10},
+		{key: "www.github.com.", value: 4},
+		{key: "www.google.com.", value: 3},
 	}) {
 		t.Error("top counters mismatch:", top3)
 	}

--- a/dogstatsd/counters_test.go
+++ b/dogstatsd/counters_test.go
@@ -1,0 +1,36 @@
+package dogstatsd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNameCounters(t *testing.T) {
+	nc := makeNameCounters()
+
+	for i := 0; i != 10; i++ {
+		nc.incr("www.segment.com.")
+	}
+
+	for i := 0; i != 4; i++ {
+		nc.incr("www.github.com.")
+	}
+
+	for i := 0; i != 3; i++ {
+		nc.incr("www.google.com.")
+	}
+
+	nc.incr("google.com.")
+	nc.incr("facebook.com.")
+	nc.incr("datadoghq.com.")
+
+	top3 := nc.top(3)
+
+	if !reflect.DeepEqual(top3, []nameCounter{
+		{name: "www.segment.com.", count: 10},
+		{name: "www.github.com.", count: 4},
+		{name: "www.google.com.", count: 3},
+	}) {
+		t.Error("top counters mismatch:", top3)
+	}
+}

--- a/dogstatsd/docker.go
+++ b/dogstatsd/docker.go
@@ -70,7 +70,13 @@ type dockerNetworkSettings struct {
 }
 
 type dockerNetwork struct {
-	IPAddress string
+	IPAMConfig dockerIPAMConfig
+	IPAddress  string
+}
+
+type dockerIPAMConfig struct {
+	IPv4Address string
+	IPv6Address string
 }
 
 type dockerImage string

--- a/dogstatsd/docker.go
+++ b/dogstatsd/docker.go
@@ -1,0 +1,101 @@
+package dogstatsd
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type dockerClient struct {
+	host string
+	http http.Client
+}
+
+func (c *dockerClient) listContainers() (containers []dockerContainer, err error) {
+	err = c.get("/containers/json", &containers)
+	return
+}
+
+func (c *dockerClient) get(url string, ret interface{}) (err error) {
+	var host = dockerHostAddr(c.host)
+	var req *http.Request
+	var res *http.Response
+
+	if len(host) == 0 {
+		return
+	}
+
+	if req, err = http.NewRequest(http.MethodGet, host+url, nil); err != nil {
+		return
+	}
+
+	if res, err = c.http.Do(req); err != nil {
+		return
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		err = fmt.Errorf("%s: %s", req.URL, res.Status)
+		return
+	}
+
+	err = json.NewDecoder(res.Body).Decode(ret)
+	return
+}
+
+type dockerContainer struct {
+	Image           dockerImage
+	NetworkSettings dockerNetworkSettings
+}
+
+type dockerNetworkSettings struct {
+	Networks map[string]dockerNetwork
+}
+
+type dockerNetwork struct {
+	IPAddress string
+}
+
+type dockerImage string
+
+func (image dockerImage) repo() string {
+	repo, _, _ := image.parts()
+	return repo
+}
+
+func (image dockerImage) name() string {
+	_, name, _ := image.parts()
+	return name
+}
+
+func (image dockerImage) version() string {
+	_, _, version := image.parts()
+	return version
+}
+
+func (image dockerImage) parts() (repo, name, version string) {
+	s := string(image)
+	i := strings.LastIndexByte(s, ':')
+	if i < 0 {
+		name = s
+	} else {
+		name, version = s[:i], s[i+1:]
+	}
+	j := strings.LastIndexByte(name, '/')
+	if j >= 0 {
+		repo, name = name[:j], name[j+1:]
+	}
+	return
+}
+
+func dockerHostAddr(host string) string {
+	if len(host) != 0 && !strings.HasPrefix(host, "http://") {
+		i := strings.Index(host, "://")
+		if i >= 0 {
+			host = host[i+3:]
+		}
+		host = "http://" + host
+	}
+	return host
+}

--- a/dogstatsd/docker_test.go
+++ b/dogstatsd/docker_test.go
@@ -1,0 +1,241 @@
+package dogstatsd
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+)
+
+func TestDockerImage(t *testing.T) {
+	tests := []struct {
+		image   dockerImage
+		repo    string
+		name    string
+		version string
+	}{
+		{
+			image:   "",
+			repo:    "",
+			name:    "",
+			version: "",
+		},
+
+		{
+			image:   "coredns",
+			repo:    "",
+			name:    "coredns",
+			version: "",
+		},
+
+		{
+			image:   "segment/coredns",
+			repo:    "segment",
+			name:    "coredns",
+			version: "",
+		},
+
+		{
+			image:   "coredns:1.0.5",
+			repo:    "",
+			name:    "coredns",
+			version: "1.0.5",
+		},
+
+		{
+			image:   "segment/coredns:1.0.5",
+			repo:    "segment",
+			name:    "coredns",
+			version: "1.0.5",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(string(test.image), func(t *testing.T) {
+			repo, name, version := test.image.parts()
+
+			if repo != test.repo {
+				t.Error("repo mismatch:", repo, "!=", test.repo)
+			}
+
+			if name != test.name {
+				t.Error("name mismatch:", name, "!=", test.name)
+			}
+
+			if version != test.version {
+				t.Error("version mismatch:", version, "!=", test.version)
+			}
+		})
+	}
+}
+
+func TestDockerClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/containers/json" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Write([]byte(`[
+  {
+    "Id": "89763c167db7c57a248a152877056cdefd4fb6dc1ab14113db3c42afc12e8574",
+    "Names": [
+      "/coredns_coredns_1"
+    ],
+    "Image": "segment/coredns:1.4.4",
+    "ImageID": "sha256:dc671f751e39f06c516452995213445ed78e97cb3f475de42df14409bf56acc5",
+    "Command": "/entrypoint.sh",
+    "Created": 1518566675,
+    "Ports": [
+      {
+        "IP": "0.0.0.0",
+        "PrivatePort": 6053,
+        "PublicPort": 6053,
+        "Type": "tcp"
+      },
+      {
+        "PrivatePort": 9053,
+        "Type": "tcp"
+      },
+      {
+        "IP": "0.0.0.0",
+        "PrivatePort": 53,
+        "PublicPort": 1053,
+        "Type": "tcp"
+      },
+      {
+        "IP": "0.0.0.0",
+        "PrivatePort": 53,
+        "PublicPort": 1053,
+        "Type": "udp"
+      }
+    ],
+    "Labels": {
+      "com.docker.compose.config-hash": "3a875203c1620a6d8f1566605beddc87bb2b9581e2f9e364d0095be99c6ead85",
+      "com.docker.compose.container-number": "1",
+      "com.docker.compose.oneoff": "False",
+      "com.docker.compose.project": "coredns",
+      "com.docker.compose.service": "coredns",
+      "com.docker.compose.version": "1.19.0-rc2"
+    },
+    "State": "running",
+    "Status": "Up 6 hours",
+    "HostConfig": {
+      "NetworkMode": "coredns_vpc"
+    },
+    "NetworkSettings": {
+      "Networks": {
+        "coredns_vpc": {
+          "IPAMConfig": {
+            "IPv4Address": "10.5.0.4"
+          },
+          "Links": null,
+          "Aliases": null,
+          "NetworkID": "937ab3d86abb7abdf9bc7e74cf3eb2c5672257836af0dc77090b236f78d37309",
+          "EndpointID": "744c0dd472509e55c4262153777a122880195edada4cc8abb0781ef2194f2758",
+          "Gateway": "10.5.0.1",
+          "IPAddress": "10.5.0.4",
+          "IPPrefixLen": 16,
+          "IPv6Gateway": "",
+          "GlobalIPv6Address": "",
+          "GlobalIPv6PrefixLen": 0,
+          "MacAddress": "02:42:0a:05:00:04",
+          "DriverOpts": null
+        }
+      }
+    },
+    "Mounts": []
+  },
+  {
+    "Id": "5cd9f15a16621239c49549eb6c741f49c0b29dc6f8cf80a964c9e7c0bbb942c7",
+    "Names": [
+      "/coredns_dogstatsd_1"
+    ],
+    "Image": "segment/dogstatsd",
+    "ImageID": "sha256:4aacb258b45b4e34717c7c1e962bae6a0ad430c3659a1290aa0387321b19372f",
+    "Command": "/dogstatsd agent",
+    "Created": 1518566674,
+    "Ports": [
+      {
+        "IP": "0.0.0.0",
+        "PrivatePort": 8125,
+        "PublicPort": 8125,
+        "Type": "udp"
+      }
+    ],
+    "Labels": {
+      "com.docker.compose.config-hash": "6ec2e9f388383ffbb18e8376f44adde36a17014830d3633a13c99d92566058f7",
+      "com.docker.compose.container-number": "1",
+      "com.docker.compose.oneoff": "False",
+      "com.docker.compose.project": "coredns",
+      "com.docker.compose.service": "dogstatsd",
+      "com.docker.compose.version": "1.19.0-rc2"
+    },
+    "State": "running",
+    "Status": "Up 6 hours",
+    "HostConfig": {
+      "NetworkMode": "coredns_vpc"
+    },
+    "NetworkSettings": {
+      "Networks": {
+        "coredns_vpc": {
+          "IPAMConfig": {
+            "IPv4Address": "10.5.0.3"
+          },
+          "Links": null,
+          "Aliases": null,
+          "NetworkID": "937ab3d86abb7abdf9bc7e74cf3eb2c5672257836af0dc77090b236f78d37309",
+          "EndpointID": "f24122dcb242b5deaefb3f7d88ec65380723763488ce1e3ff5777b4f63cc869d",
+          "Gateway": "10.5.0.1",
+          "IPAddress": "10.5.0.3",
+          "IPPrefixLen": 16,
+          "IPv6Gateway": "",
+          "GlobalIPv6Address": "",
+          "GlobalIPv6PrefixLen": 0,
+          "MacAddress": "02:42:0a:05:00:03",
+          "DriverOpts": null
+        }
+      }
+    },
+    "Mounts": []
+  }
+]
+`))
+	}))
+	defer server.Close()
+
+	client := dockerClient{
+		host: server.URL,
+	}
+
+	containers, err := client.listContainers()
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !reflect.DeepEqual(containers, []dockerContainer{
+		{
+			Image: "segment/coredns:1.4.4",
+			NetworkSettings: dockerNetworkSettings{
+				Networks: map[string]dockerNetwork{
+					"coredns_vpc": {
+						IPAddress: "10.5.0.4",
+					},
+				},
+			},
+		},
+
+		{
+			Image: "segment/dogstatsd",
+			NetworkSettings: dockerNetworkSettings{
+				Networks: map[string]dockerNetwork{
+					"coredns_vpc": {
+						IPAddress: "10.5.0.3",
+					},
+				},
+			},
+		},
+	}) {
+		t.Error(containers)
+	}
+}

--- a/dogstatsd/dogstatsd.go
+++ b/dogstatsd/dogstatsd.go
@@ -179,8 +179,17 @@ func (d *Dogstatsd) refreshDockerCache() {
 	for _, container := range containers {
 		for _, network := range container.NetworkSettings.Networks {
 			imageName := container.Image.name()
-			cache[network.IPAddress] = append(cache[network.IPAddress], imageName)
-			log.Printf("[INFO] caching docker image address: %s->%s", imageName, network.IPAddress)
+			ipAddress := network.IPAddress
+			if len(ipAddress) == 0 {
+				ipAddress = network.IPAMConfig.IPv4Address
+			}
+			if len(ipAddress) == 0 {
+				ipAddress = network.IPAMConfig.IPv6Address
+			}
+			if len(ipAddress) != 0 {
+				cache[network.IPAddress] = append(cache[network.IPAddress], imageName)
+				log.Printf("[INFO] update docker cache: %s->%s", imageName, network.IPAddress)
+			}
 		}
 	}
 

--- a/dogstatsd/dogstatsd.go
+++ b/dogstatsd/dogstatsd.go
@@ -156,12 +156,12 @@ func (d *Dogstatsd) run(ctx context.Context) {
 
 	state := make(state)
 	for {
+		d.refreshDockerCache()
+		d.reportMetrics(state)
 		select {
+		case <-ticker.C:
 		case <-ctx.Done():
 			return
-		case <-ticker.C:
-			d.refreshDockerCache()
-			d.reportMetrics(state)
 		}
 	}
 }

--- a/dogstatsd/dogstatsd.go
+++ b/dogstatsd/dogstatsd.go
@@ -178,7 +178,9 @@ func (d *Dogstatsd) refreshDockerCache() {
 
 	for _, container := range containers {
 		for _, network := range container.NetworkSettings.Networks {
-			cache[network.IPAddress] = append(cache[network.IPAddress], container.Image.name())
+			imageName := container.Image.name()
+			cache[network.IPAddress] = append(cache[network.IPAddress], imageName)
+			log.Printf("[INFO] caching docker image address: %s->%s", imageName, network.IPAddress)
 		}
 	}
 

--- a/dogstatsd/dogstatsd.go
+++ b/dogstatsd/dogstatsd.go
@@ -108,12 +108,11 @@ func (d *Dogstatsd) Name() string { return "dogstatsd" }
 
 // ServeDNS satisfies the plugin.Handler interface.
 func (d *Dogstatsd) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg) (int, error) {
-	addr := w.RemoteAddr().String()
-	addr, _, _ = net.SplitHostPort(addr)
-
 	if cache, ok := d.dockerCache.Load().(map[string][]string); ok {
-		// If we have one or more names for the address we increment the
-		// corresponding counters.
+		addr := w.RemoteAddr().String()
+		addr, _, _ = net.SplitHostPort(addr)
+		// If we have one or more client registered for the address we increment
+		// the corresponding counters.
 		for _, a := range cache[addr] {
 			d.clients.incr(a)
 			d.exchanges.incr(a + "/" + r.Question[0].Name)

--- a/dogstatsd/dogstatsd.go
+++ b/dogstatsd/dogstatsd.go
@@ -170,7 +170,7 @@ func (d *Dogstatsd) refreshDockerCache() {
 	containers, err := d.dockerClient.listContainers()
 
 	if err != nil {
-		log.Printf("[ERROR] failed to list containers from docker at %s", d.dockerClient.host)
+		log.Printf("[ERROR] failed to list containers from docker at %s: %s", d.dockerClient.host, err)
 		return
 	}
 

--- a/dogstatsd/dogstatsd.go
+++ b/dogstatsd/dogstatsd.go
@@ -187,8 +187,8 @@ func (d *Dogstatsd) refreshDockerCache() {
 				ipAddress = network.IPAMConfig.IPv6Address
 			}
 			if len(ipAddress) != 0 {
-				cache[network.IPAddress] = append(cache[network.IPAddress], imageName)
-				log.Printf("[INFO] update docker cache: %s->%s", imageName, network.IPAddress)
+				cache[ipAddress] = append(cache[ipAddress], imageName)
+				log.Printf("[INFO] update docker cache: %s->%s", imageName, ipAddress)
 			}
 		}
 	}

--- a/dogstatsd/dogstatsd_test.go
+++ b/dogstatsd/dogstatsd_test.go
@@ -94,7 +94,7 @@ func testDogstatsdSimple(t *testing.T, plugin *Dogstatsd, server server, state s
 	histogram1.Observe(42)
 	histogram1.Observe(42)
 
-	plugin.pulse(state)
+	plugin.reportMetrics(state)
 	assertRead(t, server,
 		"coredns.segment.counter1:42|c",
 		"coredns.segment.counter2:1|c",
@@ -109,7 +109,7 @@ func testDogstatsdRepeat(t *testing.T, plugin *Dogstatsd, server server, state s
 
 	for i := 0; i != 20; i++ {
 		counter2.Add(float64(i))
-		plugin.pulse(state)
+		plugin.reportMetrics(state)
 	}
 
 	assertRead(t, server,
@@ -181,7 +181,7 @@ func testDogstatsdMerge(t *testing.T, plugin *Dogstatsd, server server, state st
 		histogram1.Observe(float64(i + 1))
 	}
 
-	plugin.pulse(state)
+	plugin.reportMetrics(state)
 	assertRead(t, server,
 		"coredns.segment.histogram1:0|h|@0.1",
 		"coredns.segment.histogram1:10|h|@0.1",
@@ -208,7 +208,7 @@ func testDogstatsdGoMetrics(t *testing.T, enable bool) {
 	plugin.Reg.MustRegister(prometheus.NewGoCollector())
 	plugin.EnableGoMetrics = enable
 
-	plugin.pulse(state)
+	plugin.reportMetrics(state)
 	time.Sleep(100 * time.Millisecond)
 	server.Close()
 


### PR DESCRIPTION
This PR adds a top10 metric of most queried names. The idea is that tagging all requests with the requested name will explode the cardinality supported by datadog, but reporting on the most popular ones will give us good insights into bad behaviors while keeping the tag cardinality low enough.