### PR TITLE
refactor consul cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    working_directory: /go/src/github.com/segmentio/coredns-plugins
+    docker:
+      - image: circleci/golang
+    steps:
+      - checkout
+      - setup_remote_docker: { reusable: true, docker_layer_caching: true }
+      - run: go get -v -t ./...
+      - run: go vet ./...
+      - run: go test -v -race ./...

--- a/dogstatsd/docker_test.go
+++ b/dogstatsd/docker_test.go
@@ -275,6 +275,9 @@ func TestDockerClient(t *testing.T) {
 			NetworkSettings: dockerNetworkSettings{
 				Networks: map[string]dockerNetwork{
 					"coredns_vpc": {
+						IPAMConfig: dockerIPAMConfig{
+							IPv4Address: "10.5.0.4",
+						},
 						IPAddress: "10.5.0.4",
 					},
 				},
@@ -286,6 +289,9 @@ func TestDockerClient(t *testing.T) {
 			NetworkSettings: dockerNetworkSettings{
 				Networks: map[string]dockerNetwork{
 					"coredns_vpc": {
+						IPAMConfig: dockerIPAMConfig{
+							IPv4Address: "10.5.0.3",
+						},
 						IPAddress: "10.5.0.3",
 					},
 				},

--- a/dogstatsd/setup_test.go
+++ b/dogstatsd/setup_test.go
@@ -111,11 +111,11 @@ func TestSetupSuccess(t *testing.T) {
 			}
 
 			if d.EnableGoMetrics != test.enableGoMetrics {
-				t.Error("Expected go metrics to be %t but found: %t", test.enableGoMetrics, d.EnableGoMetrics)
+				t.Errorf("Expected go metrics to be %t but found: %t", test.enableGoMetrics, d.EnableGoMetrics)
 			}
 
 			if d.EnableProcessMetrics != test.enableProcessMetrics {
-				t.Error("Expected process metrics to be %t but found: %t", test.enableProcessMetrics, d.EnableProcessMetrics)
+				t.Errorf("Expected process metrics to be %t but found: %t", test.enableProcessMetrics, d.EnableProcessMetrics)
 			}
 		})
 	}


### PR DESCRIPTION
This PR revisits the consul cache implementation to remove all internal goroutines and instead use shared state.

I tried to avoid global locks as much as possible while keeping the logic simple so it can be easily reasoned about and easier to get right.

Please take a look and let me know if you'd like to see anything changed.