### PR TITLE
Replaced mholt with caddyserver in caddy path

### DIFF
--- a/consul/consul.go
+++ b/consul/consul.go
@@ -90,7 +90,7 @@ func (c *Consul) ServeDNS(ctx context.Context, w dns.ResponseWriter, r *dns.Msg)
 	}
 
 	state.SizeAndDo(a)
-	a, _ = state.Scrub(a)
+	a = state.Scrub(a)
 	w.WriteMsg(a)
 	return rcode, err
 }

--- a/consul/metrics.go
+++ b/consul/metrics.go
@@ -8,7 +8,7 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	metricsPlugin "github.com/coredns/coredns/plugin/metrics"
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/consul/setup.go
+++ b/consul/setup.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func init() {

--- a/consul/setup_test.go
+++ b/consul/setup_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func TestSetupSuccess(t *testing.T) {

--- a/dogstatsd/setup.go
+++ b/dogstatsd/setup.go
@@ -9,7 +9,7 @@ import (
 	"github.com/coredns/coredns/core/dnsserver"
 	"github.com/coredns/coredns/plugin"
 	"github.com/coredns/coredns/plugin/metrics"
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func init() {

--- a/dogstatsd/setup_test.go
+++ b/dogstatsd/setup_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mholt/caddy"
+	"github.com/caddyserver/caddy"
 )
 
 func TestSetupSuccess(t *testing.T) {


### PR DESCRIPTION
-path for caddy has changed
-this change is required for building new coredns image for ubuntu 18.04